### PR TITLE
to accommodate changes in networkx

### DIFF
--- a/networkdrawer.py
+++ b/networkdrawer.py
@@ -25,7 +25,8 @@ pos=nx.spring_layout(G, k=0.19, iterations=20, scale=100)
 #pos=nx.spectral_layout(G)
 #pos=nx.random_layout(G)
 
-nx.set_node_attributes(G,'pos',pos)
+# networkx ver 2.x swapped the positions of set_node_attributes' name and value arguments
+nx.set_node_attributes(G,pos,'pos')
 
 pos[-2] = [100.0, 0.0]
 pos[-1] = [0.0, 100.0]
@@ -34,7 +35,9 @@ nx.draw(G, pos=pos)
 plt.savefig("network_graph.png")
 plt.show()
 
-nodesframe = pd.DataFrame(G.node)
+# networkx ver 2.x deprecated method .node
+nodesframe = pd.DataFrame(G._node)
+
 throughputframe = nodesframe.transpose()
 outputframe = pd.concat([throughputframe['pos'].str[0],throughputframe['pos'].str[1]], axis=1)
 outputframe.columns = ['X','Y']


### PR DESCRIPTION
(new to github, my first proposed change, thx) Thanks very much for this code, it's extremely helpful. When I tried it with networkx ver 2.x I found that these edits were needed. For nx.set_node_attributes I'm sure that's correct. But for G.node the documentation (https://networkx.github.io/documentation/stable/release/migration_guide_from_1.x_to_2.0.html) indicates that G.nodes should now work -- however, I found G.nodes causes a problem later with throughputframe. I found that G._node works. (But I know it's bad form and possibly future-unstable to use a method that the networkx developer indicated was for internal use only.) I'll work on that bit more when I get time. For now, please let me know what you think, and again thanks very much.